### PR TITLE
adding time tracking tool

### DIFF
--- a/services/backend/src/api/engagement/crud.py
+++ b/services/backend/src/api/engagement/crud.py
@@ -61,13 +61,10 @@ def get_engagement_by_content_and_user_and_type(user_id, content_id, engagement_
 
 def get_time_engaged_by_user_and_controller(user_id, controller):
     try:
-        print('in get_time_engaged_by_user_and_controller')
-        print('user id:',user_id, 'controller:',controller)
         engagement_times_by_user = Engagement.query.filter_by(
-            user_id=user_id, engagement_type="MillisecondsEngagedWith"
+            user_id=user_id, engagement_type=EngagementType.MillisecondsEngagedWith
         ).all()
-        ms_engaged_by_user_with_controller = sum([min(i.engagement_value,25000) for i in engagement_times_by_user if i.engagement_metadata==controller])
-        print(ms_engaged_by_user_with_controller)
+        ms_engaged_by_user_with_controller = sum([i.engagement_value for i in engagement_times_by_user if i.engagement_metadata==controller and i.engagement_value<=25000])
         return ms_engaged_by_user_with_controller
     except Exception as e:
         print('get_time_engaged_by_user_and_controller hit an exception')

--- a/services/backend/src/api/engagement/crud.py
+++ b/services/backend/src/api/engagement/crud.py
@@ -59,6 +59,21 @@ def get_engagement_by_content_and_user_and_type(user_id, content_id, engagement_
     ).first()
 
 
+def get_time_engaged_by_user_and_controller(user_id, controller):
+    try:
+        print('in get_time_engaged_by_user_and_controller')
+        print('user id:',user_id, 'controller:',controller)
+        engagement_times_by_user = Engagement.query.filter_by(
+            user_id=user_id, engagement_type="MillisecondsEngagedWith"
+        ).all()
+        ms_engaged_by_user_with_controller = sum([i.engagement_value for i in engagement_times_by_user if i.engagement_metadata==controller])
+        print(ms_engaged_by_user_with_controller)
+        return ms_engaged_by_user_with_controller
+    except Exception as e:
+        print('get_time_engaged_by_user_and_controller hit an exception')
+        print(e)
+
+
 def add_engagement(user_id, content_id, engagement_type, engagement_value, metadata=None):
     if engagement_value is not None:
         engagement = Engagement(

--- a/services/backend/src/api/engagement/crud.py
+++ b/services/backend/src/api/engagement/crud.py
@@ -66,7 +66,7 @@ def get_time_engaged_by_user_and_controller(user_id, controller):
         engagement_times_by_user = Engagement.query.filter_by(
             user_id=user_id, engagement_type="MillisecondsEngagedWith"
         ).all()
-        ms_engaged_by_user_with_controller = sum([i.engagement_value for i in engagement_times_by_user if i.engagement_metadata==controller])
+        ms_engaged_by_user_with_controller = sum([min(i.engagement_value,25000) for i in engagement_times_by_user if i.engagement_metadata==controller])
         print(ms_engaged_by_user_with_controller)
         return ms_engaged_by_user_with_controller
     except Exception as e:

--- a/services/backend/src/api/engagement/views.py
+++ b/services/backend/src/api/engagement/views.py
@@ -7,6 +7,7 @@ from src.api.engagement.crud import (  # isort:skip
     get_all_engagements_by_content_id,
     get_engagement_by_content_and_user_and_type,
     get_engagement_count_by_content_id,
+    get_time_engaged_by_user_and_controller,
     add_engagement,
     update_engagement,
     delete_engagement,
@@ -191,9 +192,28 @@ class ElapsedTime(Resource):
         return {"message": "Success"}, 200
 
 
+class TimeEngaged(Resource):
+    @engagement_namespace.expect(parser)
+    @engagement_namespace.response(200, "Success")
+    @engagement_namespace.response(403, "Need To Login")
+    @engagement_namespace.response(401, "Bad Token, need to re-login")
+    @engagement_namespace.response(400, "Already exists")
+    def get(self, controller):
+        status_code, user_id, exception_message = get_user(request)
+        if exception_message:
+            engagement_namespace.abort(status_code, exception_message)
+            return status_code, exception_message
+        return get_time_engaged_by_user_and_controller(
+            user_id,         
+            {
+                "controller": controller
+            }
+        )
+
 engagement_namespace.add_resource(Like, "/like/<int:content_id>")
 engagement_namespace.add_resource(UnLike, "/unlike/<int:content_id>")
 engagement_namespace.add_resource(Dislike, "/dislike/<int:content_id>")
 engagement_namespace.add_resource(UnDislike, "/undislike/<int:content_id>")
 engagement_namespace.add_resource(LikeCount, "/likecount/<int:content_id>")
 engagement_namespace.add_resource(ElapsedTime, "/elapsed_time/<int:content_id>")
+engagement_namespace.add_resource(TimeEngaged, "/time_engaged/<controller>")

--- a/services/client/src/components/Feed/Feed.jsx
+++ b/services/client/src/components/Feed/Feed.jsx
@@ -144,7 +144,7 @@ const Feed = (props) => {
       })
       .catch((error) => {
         console.log("error in getTimeEngaged");
-        alert(error);
+        setButtonText("please log in");
         setLoading(false);
       });
   };

--- a/services/client/src/components/Feed/Feed.jsx
+++ b/services/client/src/components/Feed/Feed.jsx
@@ -156,12 +156,8 @@ const Feed = (props) => {
     <div className="Feed">
       <button
         className="primary"
-        style={{width: "55px",height: "30px",
-          margin: 0,
-          top: 'auto',
-          right: 20,
-          bottom: 20,
-          left: 'auto', position: 'fixed', color:'#7e95be'}}
+        // ,width: "fit-content",
+        style={{width: "60px", height: "40px", margin: 0, top: 'auto', right: 20, bottom: 20, left: 'auto', position: 'fixed', color:'#7e95be'}}
         onMouseEnter={() => getTimeEngaged()}
         onMouseLeave={() => setButtonText("time engaged")}
       >

--- a/services/client/src/components/Feed/Feed.jsx
+++ b/services/client/src/components/Feed/Feed.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-handler-names */
 import React from "react";
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, Button } from "react";
 import Post from "../Post/Post";
 import axios from "axios";
 import { getRefreshTokenIfExists } from "../../utils/tokenHandler";
@@ -119,8 +119,54 @@ const Feed = (props) => {
     });
   };
 
+
+  const getTimeEngaged = async () => {
+    console.log("in getTimeEngaged");
+    const options = {
+      method: "get",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${getRefreshTokenIfExists()}`,
+      },
+    };
+    options[
+      "url"
+    ] = `${process.env.REACT_APP_API_SERVICE_URL}/engagement/time_engaged/${fetchParams["controller"]}`; //?&controller=${fetchParams["controller"]}`;
+    setLoading(true);
+    axios(options)
+      .then((response) => {
+        const results = response.data;
+        console.log('ms engaged: '+results);
+        var minutes = Math.floor(results/60000);
+        var seconds = Math.floor((results % 60000)/1000);
+        setButtonText(minutes+"m"+seconds+"s");
+        setLoading(false);
+      })
+      .catch((error) => {
+        console.log("error in getTimeEngaged");
+        alert(error);
+        setLoading(false);
+      });
+  };
+
+
+  const [buttonText, setButtonText] = useState("time engaged")
+
   return (
     <div className="Feed">
+      <button
+        className="primary"
+        style={{width: "55px",height: "30px",
+          margin: 0,
+          top: 'auto',
+          right: 20,
+          bottom: 20,
+          left: 'auto', position: 'fixed', color:'#7e95be'}}
+        onMouseEnter={() => getTimeEngaged()}
+        onMouseLeave={() => setButtonText("time engaged")}
+      >
+          {buttonText}
+      </button>
       <label>
         Which Controller Do You Want To Use:
         <select value={fetchParams["controller"]} onChange={handleChange}>
@@ -167,3 +213,4 @@ const Feed = (props) => {
 };
 
 export default Feed;
+ 

--- a/services/client/src/components/Feed/Feed.jsx
+++ b/services/client/src/components/Feed/Feed.jsx
@@ -121,7 +121,6 @@ const Feed = (props) => {
 
 
   const getTimeEngaged = async () => {
-    console.log("in getTimeEngaged");
     const options = {
       method: "get",
       headers: {
@@ -131,19 +130,18 @@ const Feed = (props) => {
     };
     options[
       "url"
-    ] = `${process.env.REACT_APP_API_SERVICE_URL}/engagement/time_engaged/${fetchParams["controller"]}`; //?&controller=${fetchParams["controller"]}`;
+    ] = `${process.env.REACT_APP_API_SERVICE_URL}/engagement/time_engaged/${fetchParams["controller"]}`; 
     setLoading(true);
     axios(options)
       .then((response) => {
         const results = response.data;
-        console.log('ms engaged: '+results);
         var minutes = Math.floor(results/60000);
         var seconds = Math.floor((results % 60000)/1000);
         setButtonText(minutes+"m"+seconds+"s");
         setLoading(false);
       })
       .catch((error) => {
-        console.log("error in getTimeEngaged");
+        console.log("error in getTimeEngaged"+error);
         setButtonText("please log in");
         setLoading(false);
       });

--- a/services/client/src/components/Feed/Feed.jsx
+++ b/services/client/src/components/Feed/Feed.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-handler-names */
 import React from "react";
-import { useState, useEffect, useRef, useCallback, Button } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import Post from "../Post/Post";
 import axios from "axios";
 import { getRefreshTokenIfExists } from "../../utils/tokenHandler";

--- a/services/client/src/components/Feed/Feed.jsx
+++ b/services/client/src/components/Feed/Feed.jsx
@@ -156,7 +156,6 @@ const Feed = (props) => {
     <div className="Feed">
       <button
         className="primary"
-        // ,width: "fit-content",
         style={{width: "60px", height: "40px", margin: 0, top: 'auto', right: 20, bottom: 20, left: 'auto', position: 'fixed', color:'#7e95be'}}
         onMouseEnter={() => getTimeEngaged()}
         onMouseLeave={() => setButtonText("time engaged")}


### PR DESCRIPTION
Hi, I added a time tracking tool for logged in users. The user can hover over the button on the bottom right of the page to see how long they've been engaged with a specific controller. It gets the time by querying the database for total milliseconds engaged with the current controller. I've only tested it on my desktop browsers and not on mobile. [Here's](https://drive.google.com/file/d/1L0bPX1f-cfEN5JxK4KHp99EoJkFtnLbk/view?usp=sharing) what it looks like in action. 